### PR TITLE
Use `vue-gtag` for analytics

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -56,7 +56,7 @@ export default {
 
   css: ['~/assets/css/normalize.css', '~/assets/css/styles.css'],
 
-  plugins: [],
+  plugins: ['~/plugins/gtag.js'],
 
   components: ['~/components', '~/components/lib'],
 
@@ -64,13 +64,7 @@ export default {
     '@nuxtjs/eslint-module',
     '@nuxtjs/stylelint-module',
     '@nuxtjs/google-fonts',
-    '@nuxtjs/google-analytics',
   ],
-
-  googleAnalytics: {
-    id: process.env.GOOGLE_ANALYTICS_ID,
-    dev: process.env.NODE_MODULE === 'development',
-  },
 
   axios: {},
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2612,15 +2612,6 @@
         "eslint-webpack-plugin": "^2.4.1"
       }
     },
-    "@nuxtjs/google-analytics": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/google-analytics/-/google-analytics-2.4.0.tgz",
-      "integrity": "sha512-rDQTwHIjyjVrx8GywHPuWykJ3jRFGaHl5Iqji/y8tQWUc0yGEeHxOoR0yimzxnTS1Ph2/PubQYpgnVeEPEdL/A==",
-      "dev": true,
-      "requires": {
-        "vue-analytics": "^5.22.1"
-      }
-    },
     "@nuxtjs/google-fonts": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@nuxtjs/google-fonts/-/google-fonts-1.3.0.tgz",
@@ -16237,12 +16228,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
       "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
     },
-    "vue-analytics": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/vue-analytics/-/vue-analytics-5.22.1.tgz",
-      "integrity": "sha512-HPKQMN7gfcUqS5SxoO0VxqLRRSPkG1H1FqglsHccz6BatBatNtm/Vyy8brApktZxNCfnAkrSVDpxg3/FNDeOgQ==",
-      "dev": true
-    },
     "vue-client-only": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/vue-client-only/-/vue-client-only-2.1.0.tgz",
@@ -16280,6 +16265,11 @@
           "dev": true
         }
       }
+    },
+    "vue-gtag": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/vue-gtag/-/vue-gtag-1.16.1.tgz",
+      "integrity": "sha512-5vs0pSGxdqrfXqN1Qwt0ZFXG0iTYjRMu/saddc7QIC5yp+DKgjWQRpGYVa7Pq+KbThxwzzMfo0sGi7ISa6NowA=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   },
   "dependencies": {
     "core-js": "^3.15.1",
-    "nuxt": "^2.15.7"
+    "nuxt": "^2.15.7",
+    "vue-gtag": "^1.16.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.14.7",
     "@nuxtjs/eslint-config": "^6.0.1",
     "@nuxtjs/eslint-module": "^3.0.2",
-    "@nuxtjs/google-analytics": "^2.4.0",
     "@nuxtjs/google-fonts": "^1.3.0",
     "@nuxtjs/stylelint-module": "^4.0.0",
     "@vue/test-utils": "^1.2.1",

--- a/plugins/gtag.js
+++ b/plugins/gtag.js
@@ -1,0 +1,8 @@
+import Vue from 'vue'
+import VueGtag from 'vue-gtag'
+
+if (process.env.NODE_ENV === 'production') {
+  Vue.use(VueGtag, {
+    config: { id: process.env.GOOGLE_ANALYTICS_ID },
+  })
+}


### PR DESCRIPTION
Switch to `vue-gtag` for Google Analytics 4 support.