### PR TITLE
Add security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,12 +7,9 @@
     X-Content-Type-Options = "nosniff"
     Content-Security-Policy = '''
     default-src 'self';
-
     font-src 'self' fonts.gstatic.com;
-    frame-src 'self';
     img-src 'self' data:;
-    media-src 'self';
-    script-src 'self';
+    script-src 'self' googletagmanager.com;
     style-src 'self' 'unsafe-inline' fonts.googleapis.com;
 
     base-uri 'none';

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,12 @@
+[[headers]]
+  for = "/*"
+  [headers.value]
+    SameSite = "STRICT"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
+    Content-Security-Policy-Report-Only = "default-src 'none'; style-src 'none'; form-action 'none'; script-src 'none'; connect-src 'none'; img-src 'none'; base-uri 'none'; object-src 'none'; require-trusted-types-for 'script';"
+
 [build]
   command = "npm run generate"
   publish = "dist"
@@ -7,3 +16,4 @@
 
 [context.deploy-preview.environment]
   NODE_ENV = "development"
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
-    Content-Security-Policy-Report-Only = '''
+    Content-Security-Policy = '''
     default-src 'self';
 
     font-src 'self' fonts.gstatic.com;

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,15 +7,13 @@
     X-Content-Type-Options = "nosniff"
     Content-Security-Policy = '''
     default-src 'self';
-    font-src 'self' fonts.gstatic.com;
+
+    font-src 'self' fonts.gstatic.com gstatic.com *.gstatic.com;
     img-src 'self' data:;
-    script-src 'self' googletagmanager.com;
+    script-src 'self' googletagmanager.com *.googletagmanager.com;
     style-src 'self' 'unsafe-inline' fonts.googleapis.com;
 
-    base-uri 'none';
-    connect-src 'none';
-    form-action 'none';
-    object-src 'none';'''
+    connect-src 'self' arcana.network *.arcana.network google-analytics.com *.google-analytics.com list-manage.com *.list-manage.com sentry.io *.sentry.io;'''
 
 [build]
   command = "npm run generate"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,10 +10,10 @@
 
     font-src 'self' fonts.gstatic.com;
     frame-src 'self';
-    img-src 'self';
+    img-src 'self' data:;
     media-src 'self';
-    script-src 'self';
-    style-src 'self' fonts.googleapis.com;
+    script-src 'self' 'unsafe-inline';
+    style-src 'self' 'unsafe-inline' fonts.googleapis.com;
 
     base-uri 'none';
     connect-src 'none';

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
-    Content-Security-Policy-Report-Only = "default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self'; base-uri 'none'; connect-src 'self'; form-action 'none'; object-src 'none'; require-trusted-types-for 'script';"
+    Content-Security-Policy-Report-Only = "default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self'; base-uri 'none'; connect-src 'none'; form-action 'none'; object-src 'none'; require-trusted-types-for 'script';"
 
 [build]
   command = "npm run generate"

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,7 @@
     img-src 'self' data:;
     media-src 'self';
     script-src 'self' 'unsafe-inline';
-    style-src 'self' 'unsafe-inline' fonts.googleapis.com;
+    style-src 'self' fonts.googleapis.com;
 
     base-uri 'none';
     connect-src 'none';

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,7 +13,9 @@
     script-src 'self' googletagmanager.com *.googletagmanager.com;
     style-src 'self' 'unsafe-inline' fonts.googleapis.com;
 
-    connect-src 'self' arcana.network *.arcana.network google-analytics.com *.google-analytics.com list-manage.com *.list-manage.com sentry.io *.sentry.io;'''
+    connect-src 'self' arcana.network *.arcana.network google-analytics.com *.google-analytics.com list-manage.com *.list-manage.com sentry.io *.sentry.io;
+
+    object-src 'none';'''
 
 [build]
   command = "npm run generate"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,21 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
-    Content-Security-Policy-Report-Only = "default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self'; base-uri 'none'; connect-src 'none'; form-action 'none'; object-src 'none'; require-trusted-types-for 'script';"
+    Content-Security-Policy-Report-Only = '''
+    default-src 'self';
+
+    font-src 'self' fonts.gstatic.com;
+    frame-src 'self';
+    img-src 'self';
+    media-src 'self';
+    script-src 'self';
+    style-src 'self' fonts.googleapis.com;
+
+    base-uri 'none';
+    connect-src 'none';
+    form-action 'none';
+    object-src 'none';
+    require-trusted-types-for 'script';'''
 
 [build]
   command = "npm run generate"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [[headers]]
   for = "/*"
-  [headers.value]
+  [headers.values]
     SameSite = "STRICT"
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-Frame-Options = "DENY"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
-    Content-Security-Policy-Report-Only = "default-src 'none'; style-src 'none'; form-action 'none'; script-src 'none'; connect-src 'none'; img-src 'none'; base-uri 'none'; object-src 'none'; require-trusted-types-for 'script';"
+    Content-Security-Policy-Report-Only = "default-src 'self'; style-src 'self'; script-src 'self'; img-src 'self'; base-uri 'none'; connect-src 'self'; form-action 'none'; object-src 'none'; require-trusted-types-for 'script';"
 
 [build]
   command = "npm run generate"

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@
     frame-src 'self';
     img-src 'self' data:;
     media-src 'self';
-    script-src 'self' 'unsafe-inline';
+    script-src 'self';
     style-src 'self' 'unsafe-inline' fonts.googleapis.com;
 
     base-uri 'none';

--- a/netlify.toml
+++ b/netlify.toml
@@ -13,13 +13,12 @@
     img-src 'self' data:;
     media-src 'self';
     script-src 'self' 'unsafe-inline';
-    style-src 'self' fonts.googleapis.com;
+    style-src 'self' 'unsafe-inline' fonts.googleapis.com;
 
     base-uri 'none';
     connect-src 'none';
     form-action 'none';
-    object-src 'none';
-    require-trusted-types-for 'script';'''
+    object-src 'none';'''
 
 [build]
   command = "npm run generate"

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -71,6 +71,7 @@ export default {
   content: {},
 
   build: {
+    extractCSS: true,
     postcss: {
       order: 'presetEnvAndCssnanoLast',
       preset: {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -71,7 +71,6 @@ export default {
   content: {},
 
   build: {
-    extractCSS: true,
     postcss: {
       order: 'presetEnvAndCssnanoLast',
       preset: {


### PR DESCRIPTION
Resolves [AR-1901](https://team-1624093970686.atlassian.net/browse/AR-1901).

## Changes

- Add security headers including CSP.

## Notes

- I've tested the change on the [preview link](https://deploy-preview-14--arcana-testnet-website.netlify.app/) generated by Netlify using [CSP Evaluator](https://csp-evaluator.withgoogle.com/) and [Synk's Website Scanner](https://snyk.io/website-scanner/).
- Netlify injects preview pages with its own JS to embed the toolbar at the bottom. As an unintended consequence of adding these headers, the JS file is now blocked and does not render the toolbar anymore.  

## Breakdown

| Directive  | Intent |
| ------------- | ------------- |
| `default-src 'self';`  | Set the fallback source to 'self' if not explicitly set.  |
| `font-src 'self' fonts.gstatic.com gstatic.com *.gstatic.com;`  | Allow loading fonts with `@font-face` from Google Fonts.  |
| `img-src 'self' data:;`  | Allow images from the same origin or as embedded `data:` strings.  |
| `script-src 'self' googletagmanager.com *.googletagmanager.com;` | Allow scripts from same origin or from Google Analytics. |
| `style-src 'self' 'unsafe-inline' fonts.googleapis.com;` | Allow styles from same origin, inline style attributes, or from Google Fonts. Note that we should remove 'unsafe-inline' after refactoring out all inline `style` attributes. |
| `connect-src 'self' arcana.network *.arcana.network google-analytics.com *.google-analytics.com list-manage.com *.list-manage.com sentry.io *.sentry.io;` | Allow XHR requests to Arcana's own APIs, Google Analytics, Mailchimp, and Sentry. |
| `object-src 'none';` | Don't allow embedding as a plugin. |

## Tests

**CSP Evaluator**

![Screenshot 2022-03-23 at 3 56 12 PM](https://user-images.githubusercontent.com/11095038/159678772-ac4d1e90-ee2d-4f4a-82e7-2931c214215e.png)

**Synk's Website Scanner**

See the report [here](https://snyk.io/test/website-scanner/?test=220323_BiDcQP_8CJ).

## Checklist

- [x] The branch name follows the format: `developer/AR-XXX-issue-name`.
