### PR TITLE
Add links to privacy and terms of use

### DIFF
--- a/components/QuickLinks.vue
+++ b/components/QuickLinks.vue
@@ -34,7 +34,7 @@ export default {
           name: 'demo',
           title: 'Sample dApp',
           description:
-            'Refer to <a href="https://docs.beta.arcana.network/docs/demo-app/" target="_blank">code samples</a> and <a href="https://github.com/arcana-network/demo-app" target="_blank">tutorials on GitHub</a> on how to integrate and use Arcana SDKs. Check out <a href="https://demo.beta.arcana.network" target="_blank">deployed sample dApp</a>.',
+            'Refer to <a href="https://docs.beta.arcana.network/docs/overview_cs/" target="_blank">code samples</a> and <a href="https://github.com/arcana-network/sdk-demo" target="_blank">tutorials on GitHub</a> on how to integrate and use Arcana SDKs. Check out <a href="https://demo.beta.arcana.network" target="_blank">deployed sample dApp</a>.',
         },
         {
           name: 'dashboard',
@@ -52,7 +52,7 @@ export default {
           name: 'report-bugs',
           title: 'Report Bugs',
           description:
-            'Participate in our bug-bounty program. Click here to <a href="https://forum.beta.arcana.network" target="_blank">report bugs</a>.',
+            'Participate in our bug-bounty program. Click here to <a href="https://forum.arcana.network" target="_blank">report bugs</a>.',
         },
       ],
     }

--- a/components/TheFooter.vue
+++ b/components/TheFooter.vue
@@ -27,6 +27,20 @@
           cooperate in sharing logs, metrics, and other data related to
           bugs/feature suggestions, in order to help improve the Arcana Network.
         </v-text>
+        <v-text class="footer-text" line-height="1.4" :weight="400">
+          By participating, you agree to Arcana Network's
+          <a
+            href="https://github.com/arcana-network/license/blob/main/PRIVACY.md"
+            target="_blank"
+            >Privacy Policy</a
+          >
+          &
+          <a
+            href="https://github.com/arcana-network/license/blob/main/TERMS.md"
+            target="_blank"
+            >Terms of Use</a
+          >.
+        </v-text>
       </v-stack>
     </v-container>
     <div class="section-gradient" />


### PR DESCRIPTION
## Resolves

- [AR-3190](https://team-1624093970686.atlassian.net/browse/AR-3190) for the testnet website.

## Changes

- Link to Privacy and Terms pages on GitHub
- Update links to forum, code samples, and starter repo

## Screenshot

<img width="1280" alt="Screenshot 2022-06-27 at 4 21 28 PM" src="https://user-images.githubusercontent.com/11095038/175925523-aa727e71-ed77-4e22-ba4c-cf8fae2454e4.png">

## Checklist

- [x] The branch name follows the format: `developer-name/AR-XXX-issue-name`.
- [x] The changes have been tested locally.