### PR TITLE
[Hotfix] Change Discord invite link

### DIFF
--- a/components/BuildSupport.vue
+++ b/components/BuildSupport.vue
@@ -31,7 +31,7 @@
       sm-align="center"
       gap="1rem"
     >
-      <a href="https://discord.gg/w6ej4FtqYS" target="__blank">
+      <a href="https://discord.com/invite/XRscu42B8V" target="__blank">
         <v-image
           path="images/discord-white.svg"
           class="build-support-social-link"

--- a/components/HeroSection.vue
+++ b/components/HeroSection.vue
@@ -89,7 +89,7 @@
             :label-weight="600"
           />
           <a
-            href="https://discord.gg/w6ej4FtqYS"
+            href="https://discord.com/invite/XRscu42B8V"
             target="_blank"
             title="Join Discord"
             class="cta-icon"


### PR DESCRIPTION
# Resolves

- [AR-3988](https://team-1624093970686.atlassian.net/browse/AR-3988)

## Changes

Change the Discord invite link.

# Checklist

- [x] The branch name follows the format: `developer-name/AR-XXX-issue-name`.
- [x] The changes have been tested locally.